### PR TITLE
Some patches for FreeBSD and OpenBSD support

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,7 +6,7 @@ use ExtUtils::MakeMaker;
 my $meta_merge = {
     META_MERGE => {
         resources => {
-            repository => 'http://github.com//sys-ramdisk-perl',
+            repository => 'http://github.com/mschilli/sys-ramdisk-perl',
         },
     }
 };
@@ -14,9 +14,14 @@ WriteMakefile(
     'NAME'         => 'Sys::Ramdisk',
     'VERSION_FROM' => 'lib/Sys/Ramdisk.pm', # finds $VERSION
     'PREREQ_PM'    => {
-    }, # e.g., Module::Name => 1.1
+            'Log::Log4perl' => 0,
+            'Sysadm::Install' => 0.44,
+            'File::Temp' => 0,
+    },
     $ExtUtils::MakeMaker::VERSION >= 6.50 ? (%$meta_merge) : (),
     ($] >= 5.005 ?    ## Add these new keywords supported since 5.005
       (ABSTRACT_FROM => 'lib/Sys/Ramdisk.pm',
-       AUTHOR     => 'Mike Schilli <cpan@perlmeister.com>') : ()),
+       AUTHOR     => 'Mike Schilli <cpan@perlmeister.com>') : (),
+       LICENSE    => 'perl',
+    ),
 );

--- a/README
+++ b/README
@@ -55,7 +55,7 @@ METHODS
         actually landed.
 
 SUPPORTED OPERATING SYSTEMS
-    Currently, only Linux and OSX are supported.
+    Currently Linux, OSX, FreeBSD and OpenBSD are supported.
 
 LEGALESE
     Copyright 2010 by Mike Schilli, all rights reserved. This program is

--- a/lib/Sys/Ramdisk.pm
+++ b/lib/Sys/Ramdisk.pm
@@ -14,6 +14,8 @@ my %class_mapper =
   map { $_->[0] => __PACKAGE__ . "::" . $_->[1] }
     ( [linux  => "Linux"],
       [darwin => "OSX"],
+      [openbsd => "OpenBSD"],
+      [freebsd => "FreeBSD"],
     );
 
 ###########################################

--- a/lib/Sys/Ramdisk.pm
+++ b/lib/Sys/Ramdisk.pm
@@ -6,7 +6,6 @@ use warnings;
 use Log::Log4perl qw(:easy);
 use Sysadm::Install qw(:all);
 use File::Temp qw(tempdir);
-use File::Basename;
 
 our $VERSION = "0.01";
 

--- a/lib/Sys/Ramdisk.pm
+++ b/lib/Sys/Ramdisk.pm
@@ -13,8 +13,6 @@ our $VERSION = "0.01";
 my %class_mapper =
   map { $_->[0] => __PACKAGE__ . "::" . $_->[1] }
     ( [linux  => "Linux"],
-      [macos  => "OSX"],
-      [osx    => "OSX"],
       [darwin => "OSX"],
     );
 
@@ -70,30 +68,9 @@ sub os_supported_list {
 }
 
 ###########################################
-sub os_find {
-###########################################
-    my $uname = bin_find("uname");
-
-    if(! defined $uname) {
-        LOGWARN "uname command not found in PATH";
-        return undef;
-    }
-
-    my($uname_info) = tap $uname;
-    chomp $uname_info;
-
-    if(! defined $uname or length $uname == 0) {
-        LOGWARN "uname didn't return anything meaningful";
-        return undef;
-    }
-
-    return $uname_info;
-}
-
-###########################################
 sub os_class_find {
 ###########################################
-    my $os = os_find();
+    my $os = $^O;
 
     my $keyword = lc $os;
 

--- a/lib/Sys/Ramdisk/FreeBSD.pm
+++ b/lib/Sys/Ramdisk/FreeBSD.pm
@@ -1,0 +1,93 @@
+###########################################
+package Sys::Ramdisk::FreeBSD;
+###########################################
+use strict;
+use warnings;
+use Log::Log4perl qw(:easy);
+use Sysadm::Install qw(bin_find tap);
+
+use base qw(Sys::Ramdisk);
+
+###########################################
+sub mount {
+###########################################
+    my($self) = @_;
+
+      # mkdir -p /mnt/myramdisk
+      # /sbin/mdmfs -s 32m md /mnt/myramdisk
+
+     for (qw(dir size)) {
+         if(! defined $self->{ $_ }) {
+             LOGWARN "Mandatory parameter $_ not set";
+             return undef;
+         }
+     }
+
+     $self->{mdmfs}  = '/sbin/mdmfs';
+     $self->{umount} = '/sbin/umount';
+
+     my @cmd = ($self->{mdmfs},
+                "-s", $self->{size},
+                "md", $self->{dir});
+
+     INFO "Mounting ramdisk: @cmd";
+     my($stdout, $stderr, $rc) = tap @cmd;
+
+    if($rc) {
+        LOGWARN "Mount command '@cmd' failed: $stderr";
+        return;
+    }
+
+    $self->{mounted} = 1;
+
+    return 1;
+}
+
+###########################################
+sub unmount {
+###########################################
+    my($self) = @_;
+
+    return if !exists $self->{mounted};
+
+    my @cmd = ($self->{umount}, $self->{dir});
+
+    INFO "Unmounting ramdisk: @cmd";
+
+     my($stdout, $stderr, $rc) = tap @cmd;
+
+    if($rc) {
+        LOGWARN "Mount command '@cmd' failed: $stderr";
+        return;
+    }
+
+    $self->{mounted} = 0;
+
+    return 1;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Sys::Ramdisk::FreeBSD - Mount and unmount RAM disks on FreeBSD
+
+=head1 SYNOPSIS
+
+    # Use base class Sys::Ramdisk instead
+
+=head1 DESCRIPTION
+
+Sys::Ramdisk::FreeBSD mounts and unmounts RAM disks on FreeBSD.
+
+=head1 LEGALESE
+
+Copyright 2015 by Robert Drake, all rights reserved.
+This program is free software, you can redistribute it and/or
+modify it under the same terms as Perl itself.
+
+=head1 AUTHOR
+
+2015, Robert Drake <rdrake@cpan.org>

--- a/lib/Sys/Ramdisk/OpenBSD.pm
+++ b/lib/Sys/Ramdisk/OpenBSD.pm
@@ -1,0 +1,93 @@
+###########################################
+package Sys::Ramdisk::OpenBSD;
+###########################################
+use strict;
+use warnings;
+use Log::Log4perl qw(:easy);
+use Sysadm::Install qw(bin_find tap);
+
+use base qw(Sys::Ramdisk);
+
+###########################################
+sub mount {
+###########################################
+    my($self) = @_;
+
+      # mkdir -p /mnt/myramdisk
+      # mount_mfs -s 32m swap /mnt/myramdisk
+
+     for (qw(dir size)) {
+         if(! defined $self->{ $_ }) {
+             LOGWARN "Mandatory parameter $_ not set";
+             return undef;
+         }
+     }
+
+     $self->{mount_mfs}  = '/sbin/mount_mfs';
+     $self->{umount} = '/sbin/umount';
+
+     my @cmd = ($self->{mount_mfs},
+                "-s", $self->{size},
+                "swap", $self->{dir});
+
+     INFO "Mounting ramdisk: @cmd";
+     my($stdout, $stderr, $rc) = tap @cmd;
+
+    if($rc) {
+        LOGWARN "Mount command '@cmd' failed: $stderr";
+        return;
+    }
+
+    $self->{mounted} = 1;
+
+    return 1;
+}
+
+###########################################
+sub unmount {
+###########################################
+    my($self) = @_;
+
+    return if !exists $self->{mounted};
+
+    my @cmd = ($self->{umount}, $self->{dir});
+
+    INFO "Unmounting ramdisk: @cmd";
+
+     my($stdout, $stderr, $rc) = tap @cmd;
+
+    if($rc) {
+        LOGWARN "Mount command '@cmd' failed: $stderr";
+        return;
+    }
+
+    $self->{mounted} = 0;
+
+    return 1;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Sys::Ramdisk::OpenBSD - Mount and unmount RAM disks on OpenBSD
+
+=head1 SYNOPSIS
+
+    # Use base class Sys::Ramdisk instead
+
+=head1 DESCRIPTION
+
+Sys::Ramdisk::OpenBSD mounts and unmounts RAM disks on OpenBSD.
+
+=head1 LEGALESE
+
+Copyright 2015 by Robert Drake, all rights reserved.
+This program is free software, you can redistribute it and/or
+modify it under the same terms as Perl itself.
+
+=head1 AUTHOR
+
+2015, Robert Drake <rdrake@cpan.org>

--- a/t/001Basic.t
+++ b/t/001Basic.t
@@ -23,8 +23,8 @@ SKIP: {
         skip "OS '$os' not supported", $nof_tests;
     }
 
-    if(lc $os eq "linux" and $uid != 0) {
-        skip "RAM disks to be created as root on Linux - skipping tests",
+    if(lc $os ne "darwin" and $uid != 0) {
+        skip "RAM disks to be created as root on most Non-Darwin systems - skipping tests",
              $nof_tests;
     }
 

--- a/t/001Basic.t
+++ b/t/001Basic.t
@@ -14,7 +14,7 @@ my $nof_tests = 4;
 
 plan tests => $nof_tests;
 
-my $os = Sys::Ramdisk->os_find();
+my $os = $^O;
 my $supported = Sys::Ramdisk->os_class_find();
 my $uid = $>;
 
@@ -24,7 +24,7 @@ SKIP: {
     }
 
     if(lc $os eq "linux" and $uid != 0) {
-        skip "RAM disks to be created as root on Linux - skipping tests", 
+        skip "RAM disks to be created as root on Linux - skipping tests",
              $nof_tests;
     }
 


### PR DESCRIPTION
This also adds PREREQs to the Makefile, fixes the repository metadata and LICENSE to make them show up on MetaCPAN.

It also uses $^O instead of uname to determine the OS because I believe that would be more portable.  I tested on Linux, FreeBSD and OpenBSD and all systems seemed to work.
